### PR TITLE
add vitest watch mode to package.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: "lts/*"
           cache: npm
       - run: npm ci
-      - run: npm run test
+      - run: npm run test:ci
 
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: "lts/*"
           cache: npm
       - run: npm ci
-      - run: npm run test:ci
+      - run: npm test
 
   e2e:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "description": "A web app for forms generated based on GitHub projects",
   "scripts": {
     "test": "vitest",
-    "test:ci": "vitest run",
     "dev": "netlify dev",
     "vite:dev": "vite",
     "vite:build": "vite build",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0-development",
   "description": "A web app for forms generated based on GitHub projects",
   "scripts": {
-    "test": "vitest run",
+    "test:ci": "vitest run",
     "dev": "netlify dev",
     "vite:dev": "vite",
     "vite:build": "vite build",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.0-development",
   "description": "A web app for forms generated based on GitHub projects",
   "scripts": {
+    "test": "vitest",
     "test:ci": "vitest run",
     "dev": "netlify dev",
     "vite:dev": "vite",


### PR DESCRIPTION
# 📘 Description
- test(package.json): `npm test` runs `vitest` in watch mode when it's not CI mode.
- refactor(ci): rename `test` command in `.workflows/test.yml`: ~`npm run test`~ `npm test`

# 📖 Context
In local development, it's interesting to run `vitest` in watch mode (the default when running `vitest CLI`). One advantage I see is to update generated snapshots when they change or become obsolete.

`vitest` relies on `process.env.CI` to run in watch mode or not[^1][^2].

[^1]: https://vitest.dev/guide/features.html#watch-mode
[^2]: https://github.blog/changelog/2020-04-15-github-actions-sets-the-ci-environment-variable-to-true/