### PR TITLE
build(jsconfig): check types in `*.js` files by default

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,6 @@
 {
+  "extends": "@tsconfig/vite-react/tsconfig.json",
   "compilerOptions": {
-    "jsx": "react-jsx"
   },
   "include": ["src/**/*"]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "checkJs": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/vite-react/tsconfig.json",
   "compilerOptions": {
+    "checkJs": true
   },
   "include": ["src/**/*"]
 }

--- a/netlify/edge-functions/github-oauth.js
+++ b/netlify/edge-functions/github-oauth.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import {
   checkToken,
   deleteAuthorization,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@testing-library/dom": "^9.3.3",
         "@testing-library/react": "^14.1.2",
         "@testing-library/user-event": "^14.5.1",
+        "@tsconfig/vite-react": "^3.0.0",
         "@types/node": "^20.11.4",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
@@ -2125,6 +2126,12 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
+    },
+    "node_modules/@tsconfig/vite-react": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/vite-react/-/vite-react-3.0.0.tgz",
+      "integrity": "sha512-haOFbphpavQ1+eyQjeqvlz7sRkQue/bS0GvFmraHml31Ufhv+7juUSc8PVe0In7sly+n+5zTLmzc287KciiGXg==",
+      "dev": true
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@testing-library/dom": "^9.3.3",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.1",
+    "@tsconfig/vite-react": "^3.0.0",
     "@types/node": "^20.11.4",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { defineConfig, devices } from "@playwright/test";
 
 /**

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,3 @@
-//@ts-check
-
 import { Outlet } from "react-router-dom";
 import createStore from "./lib/create-store.js";
 import { OctokitProvider } from "./components/octokit-provider.js";

--- a/src/components/octokit-provider.js
+++ b/src/components/octokit-provider.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import {
   createContext,
   createElement,

--- a/src/root.jsx
+++ b/src/root.jsx
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { BaseStyles, ThemeProvider } from "@primer/react";
 
 import RootRoute from "./routes/root.jsx";

--- a/src/routes/login.jsx
+++ b/src/routes/login.jsx
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { Box, Button, StyledOcticon, Text } from "@primer/react";
 import { MarkGithubIcon, TableIcon } from "@primer/octicons-react";
 

--- a/src/routes/new.jsx
+++ b/src/routes/new.jsx
@@ -1,4 +1,3 @@
-// @ts-check
 import { useState, useContext, useEffect } from "react";
 import {
   ActionList,

--- a/src/routes/root.jsx
+++ b/src/routes/root.jsx
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { useContext } from "react";
 import { Box, Spinner } from "@primer/react";
 import { OctokitContext } from "../components/octokit-provider.js";

--- a/test/example.spec.js
+++ b/test/example.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { test, expect } from "@playwright/test";
 
 test("has title", async ({ page }) => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
 


### PR DESCRIPTION
# 📘 Description
- build(deps): add `@tsconfig/vite-react` dependency
- build(jsconfig): use `@tsconfig/vite-react` preset instead
- build(jsconfig): enable "checkJs" option
- chore(ts-check): remove unnecessary `// @ts-check` in files
- build(jsconfig): exclude 'node_modules'

# Context
This makes all the js files type-checked by default without the need to add `// @ts-check` to all the files. 

It also sets the foundations to rename the file to `tsconfig.json` the moment we consider we want to move to TypeScript.